### PR TITLE
[bazel-overlays] Add compiler-rt, libcxxabi, libcxx bazel overlays

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2695,3 +2695,30 @@ cc_library(
         "//llvm:TargetParser",
     ],
 )
+
+filegroup(
+    name = "headers",
+    srcs = glob(["lib/Headers/*"]),
+    visibility = ["//visibility:public"],
+)
+
+header_dirs =[
+    "cuda_wrappers",
+    "cuda_wrappers/bits",
+    "hlsl",
+    "llvm_libc_wrappers",
+    "llvm_libc_wrappers/llvm-libc-decls",
+    "llvm_offload_wrappers",
+    "openmp_wrappers",
+    "ppc_wrappers",
+    "zos_wrappers",
+]
+
+[
+    filegroup(
+        name = "headers_{}".format(d.replace("/", "_")),
+        srcs = glob(["lib/Headers/{}/*".format(d)]),
+        visibility = ["//visibility:public"],
+    )
+    for d in header_dirs
+]

--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -110,3 +110,1056 @@ cc_library(
         ":orc_rt_common_headers",
     ],
 )
+
+filegroup(
+    name = "fuzzer_hdrs",
+    srcs = glob(["include/fuzzer/*"]),
+)
+
+filegroup(
+    name = "orc_rt_hdrs",
+    srcs = glob(["include/orc_rt/*"]),
+)
+
+filegroup(
+    name = "profile_hdrs",
+    srcs = glob(["include/profile/*"]),
+)
+
+filegroup(
+    name = "sanitizer_hdrs",
+    srcs = glob(["include/sanitizer/*"]),
+)
+
+filegroup(
+    name = "xray_hdrs",
+    srcs = glob(["include/xray/*"]),
+)
+
+cc_library(
+    name = "compiler_rt_hdrs",
+    hdrs = glob(["include/**/*"]),
+    includes = ["compiler_rt/include"],
+)
+
+filegroup(
+    name = "asan_headers",
+    srcs = [
+        "lib/asan/asan_activation.h",
+        "lib/asan/asan_activation_flags.inc",
+        "lib/asan/asan_allocator.h",
+        "lib/asan/asan_descriptions.h",
+        "lib/asan/asan_errors.h",
+        "lib/asan/asan_fake_stack.h",
+        "lib/asan/asan_flags.h",
+        "lib/asan/asan_flags.inc",
+        "lib/asan/asan_init_version.h",
+        "lib/asan/asan_interceptors.h",
+        "lib/asan/asan_interceptors_memintrinsics.h",
+        "lib/asan/asan_interface.inc",
+        "lib/asan/asan_interface_internal.h",
+        "lib/asan/asan_internal.h",
+        "lib/asan/asan_mapping.h",
+        "lib/asan/asan_poisoning.h",
+        "lib/asan/asan_premap_shadow.h",
+        "lib/asan/asan_report.h",
+        "lib/asan/asan_scariness_score.h",
+        "lib/asan/asan_stack.h",
+        "lib/asan/asan_stats.h",
+        "lib/asan/asan_suppressions.h",
+        "lib/asan/asan_thread.h",
+    ],
+)
+
+filegroup(
+    name = "asan_sources",
+    srcs = [
+        "lib/asan/asan_activation.cpp",
+        "lib/asan/asan_allocator.cpp",
+        "lib/asan/asan_debugging.cpp",
+        "lib/asan/asan_descriptions.cpp",
+        "lib/asan/asan_errors.cpp",
+        "lib/asan/asan_fake_stack.cpp",
+        "lib/asan/asan_flags.cpp",
+        "lib/asan/asan_fuchsia.cpp",
+        "lib/asan/asan_globals.cpp",
+        "lib/asan/asan_globals_win.cpp",
+        "lib/asan/asan_interceptors.cpp",
+        "lib/asan/asan_interceptors_memintrinsics.cpp",
+        "lib/asan/asan_interceptors_vfork.S",  # Not Win32 and not Apple.
+        "lib/asan/asan_linux.cpp",
+        "lib/asan/asan_mac.cpp",
+        "lib/asan/asan_malloc_linux.cpp",
+        "lib/asan/asan_malloc_mac.cpp",
+        "lib/asan/asan_malloc_win.cpp",
+        "lib/asan/asan_memory_profile.cpp",
+        "lib/asan/asan_poisoning.cpp",
+        "lib/asan/asan_posix.cpp",
+        "lib/asan/asan_premap_shadow.cpp",
+        "lib/asan/asan_report.cpp",
+        "lib/asan/asan_rtl.cpp",
+        "lib/asan/asan_shadow_setup.cpp",
+        "lib/asan/asan_stack.cpp",
+        "lib/asan/asan_stats.cpp",
+        "lib/asan/asan_suppressions.cpp",
+        "lib/asan/asan_thread.cpp",
+        "lib/asan/asan_win.cpp",
+    ],
+)
+
+filegroup(
+    name = "asan_cxx_sources",
+    srcs = [
+        "lib/asan/asan_new_delete.cpp",
+    ],
+)
+
+filegroup(
+    name = "asan_static_sources",
+    srcs = [
+        "lib/asan/asan_rtl_static.cpp",
+        "lib/asan/asan_rtl_x86_64.S",  # Not Win32 and not Apple.
+    ],
+)
+
+filegroup(
+    name = "asan_preinit_sources",
+    srcs = [
+        "lib/asan/asan_preinit.cpp",
+    ],
+)
+
+cc_library(
+    name = "RTAsan_dynamic",
+    srcs = [
+        ":asan_cxx_sources",
+        ":asan_sources",
+    ],
+    hdrs = [
+        ":asan_headers",
+        ":interception_headers",
+        ":lsan_headers",
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    defines = ["ASAN_DYNAMIC=1"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTAsan",
+    srcs = [
+        ":asan_sources",
+    ],
+    hdrs = [
+        ":asan_headers",
+        ":interception_headers",
+        ":lsan_headers",
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTAsan_cxx",
+    srcs = [
+        ":asan_cxx_sources",
+    ],
+    hdrs = [
+        ":asan_headers",
+        ":interception_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTAsan_static",
+    srcs = [
+        "lib/asan/asan_rtl_static.cpp",
+        "lib/asan/asan_rtl_x86_64.S",  # Not Win32 and not Apple.
+    ],
+    hdrs = [
+        ":asan_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTAsan_preinit",
+    srcs = [
+        ":asan_preinit_sources",
+    ],
+    hdrs = [
+        ":asan_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "clang_rt.asan",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTAsan",
+        ":RTAsan_preinit",
+        ":RTInterception",
+        ":RTLSanCommon",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+        ":RTUbsan",
+    ],
+)
+
+cc_library(
+    # We want the output library to be named libasan.so. Otherwise it will not
+    # be recognized by IsDynamicRTName in asan_linux.cpp.
+    name = "libasan",
+    linkopts = [
+        "--eh-frame-hdr",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTAsan_dynamic",
+        ":RTInterception",
+        ":RTLSanCommon",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+        ":RTUbsan",
+        ":RTUbsan_cxx",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.asan_cxx",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTAsan_cxx",
+        ":RTUbsan_cxx",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.asan_static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTAsan_static",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.asan-preinit",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTAsan_preinit",
+    ],
+)
+
+GENERIC_SOURCES = [
+    "lib/builtins/absvdi2.c",
+    "lib/builtins/absvsi2.c",
+    "lib/builtins/absvti2.c",
+    "lib/builtins/adddf3.c",
+    "lib/builtins/addsf3.c",
+    "lib/builtins/addvdi3.c",
+    "lib/builtins/addvsi3.c",
+    "lib/builtins/addvti3.c",
+    "lib/builtins/apple_versioning.c",
+    "lib/builtins/ashldi3.c",
+    "lib/builtins/ashlti3.c",
+    "lib/builtins/ashrdi3.c",
+    "lib/builtins/ashrti3.c",
+    "lib/builtins/bswapdi2.c",
+    "lib/builtins/bswapsi2.c",
+    "lib/builtins/clzdi2.c",
+    "lib/builtins/clzsi2.c",
+    "lib/builtins/clzti2.c",
+    "lib/builtins/cmpdi2.c",
+    "lib/builtins/cmpti2.c",
+    "lib/builtins/comparedf2.c",
+    "lib/builtins/comparesf2.c",
+    "lib/builtins/ctzdi2.c",
+    "lib/builtins/ctzsi2.c",
+    "lib/builtins/ctzti2.c",
+    "lib/builtins/divdc3.c",
+    "lib/builtins/divdf3.c",
+    "lib/builtins/divdi3.c",
+    "lib/builtins/divmoddi4.c",
+    "lib/builtins/divmodsi4.c",
+    "lib/builtins/divmodti4.c",
+    "lib/builtins/divsc3.c",
+    "lib/builtins/divsf3.c",
+    "lib/builtins/divsi3.c",
+    "lib/builtins/divti3.c",
+    "lib/builtins/extendsfdf2.c",
+    "lib/builtins/extendhfsf2.c",
+    "lib/builtins/ffsdi2.c",
+    "lib/builtins/ffssi2.c",
+    "lib/builtins/ffsti2.c",
+    "lib/builtins/fixdfdi.c",
+    "lib/builtins/fixdfsi.c",
+    "lib/builtins/fixdfti.c",
+    "lib/builtins/fixsfdi.c",
+    "lib/builtins/fixsfsi.c",
+    "lib/builtins/fixsfti.c",
+    "lib/builtins/fixunsdfdi.c",
+    "lib/builtins/fixunsdfsi.c",
+    "lib/builtins/fixunsdfti.c",
+    "lib/builtins/fixunssfdi.c",
+    "lib/builtins/fixunssfsi.c",
+    "lib/builtins/fixunssfti.c",
+    "lib/builtins/floatdidf.c",
+    "lib/builtins/floatdisf.c",
+    "lib/builtins/floatsidf.c",
+    "lib/builtins/floatsisf.c",
+    "lib/builtins/floattidf.c",
+    "lib/builtins/floattisf.c",
+    "lib/builtins/floatundidf.c",
+    "lib/builtins/floatundisf.c",
+    "lib/builtins/floatunsidf.c",
+    "lib/builtins/floatunsisf.c",
+    "lib/builtins/floatuntidf.c",
+    "lib/builtins/floatuntisf.c",
+    "lib/builtins/fp_mode.c",
+    "lib/builtins/int_util.c",
+    "lib/builtins/lshrdi3.c",
+    "lib/builtins/lshrti3.c",
+    "lib/builtins/moddi3.c",
+    "lib/builtins/modsi3.c",
+    "lib/builtins/modti3.c",
+    "lib/builtins/muldc3.c",
+    "lib/builtins/muldf3.c",
+    "lib/builtins/muldi3.c",
+    "lib/builtins/mulodi4.c",
+    "lib/builtins/mulosi4.c",
+    "lib/builtins/muloti4.c",
+    "lib/builtins/mulsc3.c",
+    "lib/builtins/mulsf3.c",
+    "lib/builtins/multi3.c",
+    "lib/builtins/mulvdi3.c",
+    "lib/builtins/mulvsi3.c",
+    "lib/builtins/mulvti3.c",
+    "lib/builtins/negdf2.c",
+    "lib/builtins/negdi2.c",
+    "lib/builtins/negsf2.c",
+    "lib/builtins/negti2.c",
+    "lib/builtins/negvdi2.c",
+    "lib/builtins/negvsi2.c",
+    "lib/builtins/negvti2.c",
+    "lib/builtins/os_version_check.c",
+    "lib/builtins/paritydi2.c",
+    "lib/builtins/paritysi2.c",
+    "lib/builtins/parityti2.c",
+    "lib/builtins/popcountdi2.c",
+    "lib/builtins/popcountsi2.c",
+    "lib/builtins/popcountti2.c",
+    "lib/builtins/powidf2.c",
+    "lib/builtins/powisf2.c",
+    "lib/builtins/subdf3.c",
+    "lib/builtins/subsf3.c",
+    "lib/builtins/subvdi3.c",
+    "lib/builtins/subvsi3.c",
+    "lib/builtins/subvti3.c",
+    "lib/builtins/trampoline_setup.c",
+    "lib/builtins/truncdfhf2.c",
+    "lib/builtins/truncdfsf2.c",
+    "lib/builtins/truncsfhf2.c",
+    "lib/builtins/ucmpdi2.c",
+    "lib/builtins/ucmpti2.c",
+    "lib/builtins/udivdi3.c",
+    "lib/builtins/udivmoddi4.c",
+    "lib/builtins/udivmodsi4.c",
+    "lib/builtins/udivmodti4.c",
+    "lib/builtins/udivsi3.c",
+    "lib/builtins/udivti3.c",
+    "lib/builtins/umoddi3.c",
+    "lib/builtins/umodsi3.c",
+    "lib/builtins/umodti3.c",
+
+    # Not Fuchsia and not a bare-metal build.
+    "lib/builtins/emutls.c",
+    "lib/builtins/enable_execute_stack.c",
+    "lib/builtins/eprintf.c",
+
+    # Not sure whether we want atomic in this or separately.
+    "lib/builtins/atomic.c",
+
+    # Not sure whether this is for libunwind or gcc_s. gotta check.
+    "lib/builtins/gcc_personality_v0.c",
+
+    # Not Fuchsia.
+    "lib/builtins/clear_cache.c",
+]
+
+GENERIC_TF_SOURCES = [
+    "lib/builtins/addtf3.c",
+    "lib/builtins/comparetf2.c",
+    "lib/builtins/divtc3.c",
+    "lib/builtins/divtf3.c",
+    "lib/builtins/extenddftf2.c",
+    "lib/builtins/extendhftf2.c",
+    "lib/builtins/extendsftf2.c",
+    "lib/builtins/fixtfdi.c",
+    "lib/builtins/fixtfsi.c",
+    "lib/builtins/fixtfti.c",
+    "lib/builtins/fixunstfdi.c",
+    "lib/builtins/fixunstfsi.c",
+    "lib/builtins/fixunstfti.c",
+    "lib/builtins/floatditf.c",
+    "lib/builtins/floatsitf.c",
+    "lib/builtins/floattitf.c",
+    "lib/builtins/floatunditf.c",
+    "lib/builtins/floatunsitf.c",
+    "lib/builtins/floatuntitf.c",
+    "lib/builtins/multc3.c",
+    "lib/builtins/multf3.c",
+    "lib/builtins/powitf2.c",
+    "lib/builtins/subtf3.c",
+    "lib/builtins/trunctfdf2.c",
+    "lib/builtins/trunctfhf2.c",
+    "lib/builtins/trunctfsf2.c",
+]
+
+X86_ARCH_SOURCES = [
+    "lib/builtins/cpu_model/x86.c",
+    "lib/builtins/i386/fp_mode.c",  # Used on 64-bit as well.
+]
+
+X86_80_BIT_SOURCES = [
+    "lib/builtins/divxc3.c",
+    "lib/builtins/extendxftf2.c",
+    "lib/builtins/fixxfdi.c",
+    "lib/builtins/fixxfti.c",
+    "lib/builtins/fixunsxfdi.c",
+    "lib/builtins/fixunsxfsi.c",
+    "lib/builtins/fixunsxfti.c",
+    "lib/builtins/floatdixf.c",
+    "lib/builtins/floattixf.c",
+    "lib/builtins/floatundixf.c",
+    "lib/builtins/floatuntixf.c",
+    "lib/builtins/mulxc3.c",
+    "lib/builtins/powixf2.c",
+    "lib/builtins/trunctfxf2.c",
+]
+
+X86_64_SOURCES = GENERIC_SOURCES + GENERIC_TF_SOURCES + X86_ARCH_SOURCES + X86_80_BIT_SOURCES + [
+    "lib/builtins/x86_64/floatdidf.c",
+    "lib/builtins/x86_64/floatdisf.c",
+    "lib/builtins/x86_64/floatundidf.S",
+    "lib/builtins/x86_64/floatundisf.S",
+    "lib/builtins/x86_64/floatdixf.c",
+    "lib/builtins/x86_64/floatundixf.S",
+]
+
+cc_library(
+    name = "builtins",
+    srcs = X86_64_SOURCES,
+    hdrs = [
+        "lib/builtins/assembly.h",
+        "lib/builtins/cpu_model/cpu_model.h",
+        "lib/builtins/fp_add_impl.inc",
+        "lib/builtins/fp_compare_impl.inc",
+        "lib/builtins/fp_div_impl.inc",
+        "lib/builtins/fp_extend.h",
+        "lib/builtins/fp_extend_impl.inc",
+        "lib/builtins/fp_fixint_impl.inc",
+        "lib/builtins/fp_fixuint_impl.inc",
+        "lib/builtins/fp_lib.h",
+        "lib/builtins/fp_mode.h",
+        "lib/builtins/fp_mul_impl.inc",
+        "lib/builtins/fp_trunc.h",
+        "lib/builtins/fp_trunc_impl.inc",
+        "lib/builtins/int_div_impl.inc",
+        "lib/builtins/int_endianness.h",
+        "lib/builtins/int_lib.h",
+        "lib/builtins/int_math.h",
+        "lib/builtins/int_mulo_impl.inc",
+        "lib/builtins/int_mulv_impl.inc",
+        "lib/builtins/int_to_fp.h",
+        "lib/builtins/int_to_fp_impl.inc",
+        "lib/builtins/int_types.h",
+        "lib/builtins/int_util.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crtbegin",
+    srcs = ["lib/builtins/crtbegin.c"],
+    defines = ["EH_USE_FRAME_REGISTRY"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crtend",
+    srcs = ["lib/builtins/crtend.c"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crt",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":crtbegin",
+        ":crtend",
+    ],
+)
+
+filegroup(
+    name = "interception_headers",
+    srcs = [
+        "lib/interception/interception.h",
+        "lib/interception/interception_linux.h",
+        "lib/interception/interception_mac.h",
+        "lib/interception/interception_win.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTInterception",
+    srcs = [
+        "lib/interception/interception_linux.cpp",
+        "lib/interception/interception_mac.cpp",
+        "lib/interception/interception_type_test.cpp",
+        "lib/interception/interception_win.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "lsan_headers",
+    srcs = [
+        "lib/lsan/lsan.h",
+        "lib/lsan/lsan_allocator.h",
+        "lib/lsan/lsan_common.h",
+        "lib/lsan/lsan_flags.inc",
+        "lib/lsan/lsan_posix.h",  # Missing in CMake.
+        "lib/lsan/lsan_thread.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTLSanCommon",
+    srcs = [
+        "lib/lsan/lsan_common.cpp",
+        "lib/lsan/lsan_common_fuchsia.cpp",
+        "lib/lsan/lsan_common_linux.cpp",
+        "lib/lsan/lsan_common_mac.cpp",
+    ],
+    hdrs = [
+        ":lsan_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "clang_rt.lsan",
+    srcs = [
+        "lib/lsan/lsan.cpp",
+        "lib/lsan/lsan_allocator.cpp",
+        "lib/lsan/lsan_fuchsia.cpp",
+        "lib/lsan/lsan_interceptors.cpp",
+        "lib/lsan/lsan_linux.cpp",
+        "lib/lsan/lsan_mac.cpp",
+        "lib/lsan/lsan_malloc_mac.cpp",
+        "lib/lsan/lsan_posix.cpp",
+        "lib/lsan/lsan_preinit.cpp",
+        "lib/lsan/lsan_thread.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":lsan_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTInterception",
+        ":RTLSanCommon",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+    ],
+)
+
+filegroup(
+    name = "msan_headers",
+    srcs = [
+        "lib/msan/msan.h",
+        "lib/msan/msan_allocator.h",
+        "lib/msan/msan_chained_origin_depot.h",
+        "lib/msan/msan_dl.h",
+        "lib/msan/msan_flags.h",
+        "lib/msan/msan_flags.inc",
+        "lib/msan/msan_interface_internal.h",
+        "lib/msan/msan_origin.h",
+        "lib/msan/msan_poisoning.h",
+        "lib/msan/msan_report.h",
+        "lib/msan/msan_thread.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "clang_rt.msan",
+    srcs = [
+        "lib/msan/msan.cpp",
+        "lib/msan/msan_allocator.cpp",
+        "lib/msan/msan_chained_origin_depot.cpp",
+        "lib/msan/msan_dl.cpp",
+        "lib/msan/msan_interceptors.cpp",
+        "lib/msan/msan_linux.cpp",
+        "lib/msan/msan_poisoning.cpp",
+        "lib/msan/msan_report.cpp",
+        "lib/msan/msan_thread.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":msan_headers",
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTInterception",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+        ":RTUbsan",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.msan_cxx",
+    srcs = [
+        "lib/msan/msan_new_delete.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":msan_headers",
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTUbsan_cxx",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.profile",
+    srcs = glob([
+        "lib/profile/*.c",
+    ]),
+    hdrs = glob([
+        "lib/profile/*.h",
+    ]),
+    defines = [
+        "COMPILER_RT_HAS_UNAME=1",
+        "COMPILER_RT_HAS_FCNTL_LCK=1",
+        "COMPILER_RT_HAS_ATOMICS=1",
+    ],
+    includes = [
+        "compiler-rt/include",
+        "lib",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":compiler_rt_hdrs"],
+)
+
+filegroup(
+    name = "sanitizer_impl_headers",
+    srcs = glob([
+        "lib/sanitizer_common/*.h",
+        "lib/sanitizer_common/*.inc",
+        "lib/sanitizer_common/*.inc.S",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTSanitizerCommon",
+    srcs = [
+        "lib/sanitizer_common/sanitizer_allocator.cpp",
+        "lib/sanitizer_common/sanitizer_common.cpp",
+        "lib/sanitizer_common/sanitizer_deadlock_detector1.cpp",
+        "lib/sanitizer_common/sanitizer_deadlock_detector2.cpp",
+        "lib/sanitizer_common/sanitizer_errno.cpp",
+        "lib/sanitizer_common/sanitizer_file.cpp",
+        "lib/sanitizer_common/sanitizer_flags.cpp",
+        "lib/sanitizer_common/sanitizer_flag_parser.cpp",
+        "lib/sanitizer_common/sanitizer_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_libc.cpp",
+        "lib/sanitizer_common/sanitizer_libignore.cpp",
+        "lib/sanitizer_common/sanitizer_linux.cpp",
+        "lib/sanitizer_common/sanitizer_linux_s390.cpp",
+        "lib/sanitizer_common/sanitizer_mac.cpp",
+        "lib/sanitizer_common/sanitizer_mutex.cpp",
+        "lib/sanitizer_common/sanitizer_netbsd.cpp",
+        "lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp",
+        "lib/sanitizer_common/sanitizer_platform_limits_linux.cpp",
+        "lib/sanitizer_common/sanitizer_platform_limits_netbsd.cpp",
+        "lib/sanitizer_common/sanitizer_platform_limits_posix.cpp",
+        "lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp",
+        "lib/sanitizer_common/sanitizer_posix.cpp",
+        "lib/sanitizer_common/sanitizer_printf.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_common.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_bsd.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_linux.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_mac.cpp",
+        "lib/sanitizer_common/sanitizer_procmaps_solaris.cpp",
+        "lib/sanitizer_common/sanitizer_range.cpp",
+        "lib/sanitizer_common/sanitizer_solaris.cpp",
+        "lib/sanitizer_common/sanitizer_stoptheworld_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_stoptheworld_mac.cpp",
+        "lib/sanitizer_common/sanitizer_stoptheworld_win.cpp",
+        "lib/sanitizer_common/sanitizer_suppressions.cpp",
+        "lib/sanitizer_common/sanitizer_tls_get_addr.cpp",
+        "lib/sanitizer_common/sanitizer_thread_arg_retval.cpp",
+        "lib/sanitizer_common/sanitizer_thread_registry.cpp",
+        "lib/sanitizer_common/sanitizer_type_traits.cpp",
+        "lib/sanitizer_common/sanitizer_win.cpp",
+        "lib/sanitizer_common/sanitizer_win_interception.cpp",
+
+        # Always termination.
+        "lib/sanitizer_common/sanitizer_termination.cpp",
+    ],
+    hdrs = [":sanitizer_impl_headers"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTSanitizerCommonNoLibc",
+    srcs = [
+        "lib/sanitizer_common/sanitizer_common_nolibc.cpp",
+    ],
+    hdrs = [":sanitizer_impl_headers"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTSanitizerCommonLibc",
+    srcs = [
+        "lib/sanitizer_common/sanitizer_allocator_checks.cpp",
+        "lib/sanitizer_common/sanitizer_common_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_dl.cpp",
+        "lib/sanitizer_common/sanitizer_linux_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_mac_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_posix_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_stoptheworld_netbsd_libcdep.cpp",
+    ],
+    hdrs = [":sanitizer_impl_headers"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTSanitizerCommonCoverage",
+    srcs = [
+        "lib/sanitizer_common/sancov_flags.cpp",
+        "lib/sanitizer_common/sanitizer_coverage_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_coverage_libcdep_new.cpp",
+        "lib/sanitizer_common/sanitizer_coverage_win_sections.cpp",
+    ],
+    hdrs = [":sanitizer_impl_headers"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTSanitizerCommonSymbolizer",
+    srcs = [
+        "lib/sanitizer_common/sanitizer_allocator_report.cpp",
+        "lib/sanitizer_common/sanitizer_chained_origin_depot.cpp",
+        "lib/sanitizer_common/sanitizer_stack_store.cpp",
+        "lib/sanitizer_common/sanitizer_stackdepot.cpp",
+        "lib/sanitizer_common/sanitizer_stacktrace.cpp",
+        "lib/sanitizer_common/sanitizer_stacktrace_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_stacktrace_printer.cpp",
+        "lib/sanitizer_common/sanitizer_stacktrace_sparc.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_libbacktrace.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_mac.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_markup.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_markup_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_posix_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_report.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_report_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_symbolizer_win.cpp",
+        "lib/sanitizer_common/sanitizer_unwind_fuchsia.cpp",
+        "lib/sanitizer_common/sanitizer_unwind_linux_libcdep.cpp",
+        "lib/sanitizer_common/sanitizer_unwind_win.cpp",
+    ],
+    hdrs = [":sanitizer_impl_headers"],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "tsan_headers",
+    srcs = [
+        "lib/tsan/rtl/tsan_defs.h",
+        "lib/tsan/rtl/tsan_dense_alloc.h",
+        "lib/tsan/rtl/tsan_fd.h",
+        "lib/tsan/rtl/tsan_flags.h",
+        "lib/tsan/rtl/tsan_flags.inc",
+        "lib/tsan/rtl/tsan_ignoreset.h",
+        "lib/tsan/rtl/tsan_ilist.h",
+        "lib/tsan/rtl/tsan_interceptors.h",
+        "lib/tsan/rtl/tsan_interface.h",
+        "lib/tsan/rtl/tsan_interface.inc",
+        "lib/tsan/rtl/tsan_interface_ann.h",
+        "lib/tsan/rtl/tsan_interface_java.h",
+        "lib/tsan/rtl/tsan_mman.h",
+        "lib/tsan/rtl/tsan_mutexset.h",
+        "lib/tsan/rtl/tsan_platform.h",
+        "lib/tsan/rtl/tsan_ppc_regs.h",
+        "lib/tsan/rtl/tsan_report.h",
+        "lib/tsan/rtl/tsan_rtl.h",
+        "lib/tsan/rtl/tsan_shadow.h",
+        "lib/tsan/rtl/tsan_stack_trace.h",
+        "lib/tsan/rtl/tsan_suppressions.h",
+        "lib/tsan/rtl/tsan_symbolize.h",
+        "lib/tsan/rtl/tsan_sync.h",
+        "lib/tsan/rtl/tsan_trace.h",
+        "lib/tsan/rtl/tsan_vector_clock.h",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.tsan",
+    srcs = [
+        # TSAN_SOURCES.
+        "lib/tsan/rtl/tsan_debugging.cpp",
+        "lib/tsan/rtl/tsan_external.cpp",
+        "lib/tsan/rtl/tsan_fd.cpp",
+        "lib/tsan/rtl/tsan_flags.cpp",
+        "lib/tsan/rtl/tsan_ignoreset.cpp",
+        "lib/tsan/rtl/tsan_interceptors_memintrinsics.cpp",
+        "lib/tsan/rtl/tsan_interceptors_posix.cpp",
+        "lib/tsan/rtl/tsan_interface.cpp",
+        "lib/tsan/rtl/tsan_interface_ann.cpp",
+        "lib/tsan/rtl/tsan_interface_atomic.cpp",
+        "lib/tsan/rtl/tsan_interface_java.cpp",
+        "lib/tsan/rtl/tsan_malloc_mac.cpp",
+        "lib/tsan/rtl/tsan_md5.cpp",
+        "lib/tsan/rtl/tsan_mman.cpp",
+        "lib/tsan/rtl/tsan_mutexset.cpp",
+        "lib/tsan/rtl/tsan_report.cpp",
+        "lib/tsan/rtl/tsan_rtl.cpp",
+        "lib/tsan/rtl/tsan_rtl_access.cpp",
+        "lib/tsan/rtl/tsan_rtl_mutex.cpp",
+        "lib/tsan/rtl/tsan_rtl_proc.cpp",
+        "lib/tsan/rtl/tsan_rtl_report.cpp",
+        "lib/tsan/rtl/tsan_rtl_thread.cpp",
+        "lib/tsan/rtl/tsan_stack_trace.cpp",
+        "lib/tsan/rtl/tsan_suppressions.cpp",
+        "lib/tsan/rtl/tsan_symbolize.cpp",
+        "lib/tsan/rtl/tsan_sync.cpp",
+        "lib/tsan/rtl/tsan_vector_clock.cpp",
+
+        # TSAN_ASM_SOURCES.
+        "lib/tsan/rtl/tsan_rtl_amd64.S",
+
+        # TSAN_PREINIT_SOURCES.
+        "lib/tsan/rtl/tsan_preinit.cpp",
+
+        # Linux sources.
+        "lib/tsan/rtl/tsan_platform_linux.cpp",
+        "lib/tsan/rtl/tsan_platform_posix.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":sanitizer_impl_headers",
+        ":tsan_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTInterception",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+        ":RTUbsan",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.tsan_cxx",
+    srcs = [
+        "lib/tsan/rtl/tsan_new_delete.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":sanitizer_impl_headers",
+        ":tsan_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTUbsan_cxx",
+    ],
+)
+
+filegroup(
+    name = "ubsan_headers",
+    srcs = [
+        "lib/ubsan/ubsan_checks.inc",
+        "lib/ubsan/ubsan_diag.h",
+        "lib/ubsan/ubsan_flags.h",
+        "lib/ubsan/ubsan_flags.inc",
+        "lib/ubsan/ubsan_handlers.h",
+        "lib/ubsan/ubsan_handlers_cxx.h",
+        "lib/ubsan/ubsan_init.h",
+        "lib/ubsan/ubsan_interface.inc",
+        "lib/ubsan/ubsan_monitor.h",
+        "lib/ubsan/ubsan_platform.h",
+        "lib/ubsan/ubsan_signals_standalone.h",
+        "lib/ubsan/ubsan_type_hash.h",
+        "lib/ubsan/ubsan_value.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTUbsan",
+    srcs = [
+        "lib/ubsan/ubsan_diag.cpp",
+        "lib/ubsan/ubsan_flags.cpp",
+        "lib/ubsan/ubsan_handlers.cpp",
+        "lib/ubsan/ubsan_init.cpp",
+        "lib/ubsan/ubsan_monitor.cpp",
+        "lib/ubsan/ubsan_value.cpp",
+    ],
+    hdrs = [
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    defines = [
+        "UBSAN_CAN_USE_CXXABI",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTUbsan_cxx",
+    srcs = [
+        "lib/ubsan/ubsan_handlers_cxx.cpp",
+        "lib/ubsan/ubsan_type_hash.cpp",
+        "lib/ubsan/ubsan_type_hash_itanium.cpp",
+        "lib/ubsan/ubsan_type_hash_win.cpp",
+    ],
+    hdrs = [
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "RTUbsan_standalone",
+    srcs = [
+        "lib/ubsan/ubsan_diag_standalone.cpp",
+        "lib/ubsan/ubsan_init_standalone.cpp",
+        "lib/ubsan/ubsan_signals_standalone.cpp",
+    ],
+    hdrs = [
+        ":interception_headers",
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "clang_rt.ubsan_standalone",
+    srcs = [
+        "lib/ubsan/ubsan_init_standalone_preinit.cpp",
+    ],
+    hdrs = [
+        ":sanitizer_impl_headers",
+        ":ubsan_headers",
+    ],
+    includes = ["lib"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTInterception",
+        ":RTSanitizerCommon",
+        ":RTSanitizerCommonCoverage",
+        ":RTSanitizerCommonLibc",
+        ":RTSanitizerCommonSymbolizer",
+        ":RTUbsan",
+        ":RTUbsan_standalone",
+    ],
+)
+
+cc_library(
+    name = "clang_rt.ubsan_standalone_cxx",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":RTUbsan_cxx",
+    ],
+)
+
+filegroup(
+    name = "asan_ignorelist",
+    srcs = [
+        "lib/asan/asan_ignorelist.txt",
+    ],
+)
+
+filegroup(
+    name = "hwasan_ignorelist",
+    srcs = [
+        "lib/hwasan/hwasan_ignorelist.txt",
+    ],
+)
+
+filegroup(
+    name = "msan_ignorelist",
+    srcs = [
+        "lib/msan/msan_ignorelist.txt",
+    ],
+)
+
+filegroup(
+    name = "cfi_ignorelist",
+    srcs = [
+        "lib/cfi/cfi_ignorelist.txt",
+    ],
+)

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1513,6 +1513,7 @@ libc_support_library(
         ":__support_str_to_float",
         ":__support_str_to_integer",
     ],
+    includes = ["."],
 )
 
 ############################### errno targets ################################

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -39,12 +39,14 @@ def _libc_library(name, hidden, copts = [], deps = [], local_defines = [], **kwa
     # See src/__support/common.h for more information.
     if hidden:
         copts = copts + ["-fvisibility=hidden"]
+    defines = kwargs.pop("defines", [])
     native.cc_library(
         name = name,
         copts = copts + libc_common_copts(),
         local_defines = local_defines + LIBC_CONFIGURE_OPTIONS,
         deps = deps,
         linkstatic = 1,
+        defines = defines + ["LIBC_NAMESPACE=" + LIBC_NAMESPACE],
         **kwargs
     )
 

--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -10,6 +10,7 @@ is discoverable with the following command:
 
 > git grep -hoE '\bLIBC_COPT_\\w*'  -- '*.h' '*.cpp' | sort -u
 """
+load("//libc:libc_namespace.bzl", "LIBC_NAMESPACE")
 
 # This list of definitions is used to customize LLVM libc.
 LIBC_CONFIGURE_OPTIONS = [

--- a/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
@@ -1,0 +1,429 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+STD_PARTITIONS = [
+    "algorithm",
+    "any",
+    "array",
+    "atomic",
+    "barrier",
+    "bit",
+    "bitset",
+    "cassert",
+    "cctype",
+    "cerrno",
+    "cfenv",
+    "cfloat",
+    "charconv",
+    "chrono",
+    "cinttypes",
+    "climits",
+    "clocale",
+    "cmath",
+    "codecvt",
+    "compare",
+    "complex",
+    "concepts",
+    "condition_variable",
+    "coroutine",
+    "csetjmp",
+    "csignal",
+    "cstdarg",
+    "cstddef",
+    "cstdio",
+    "cstdlib",
+    "cstdint",
+    "cstring",
+    "ctime",
+    "cuchar",
+    "cwchar",
+    "cwctype",
+    "deque",
+    "exception",
+    "execution",
+    # "expected", # TODO(aaronmondal): This clashes with exception. It should
+    # work, but somehow this buildfile is misconfigured.
+    "filesystem",
+    "flat_map",
+    "flat_set",
+    "format",
+    "forward_list",
+    "fstream",
+    "functional",
+    "future",
+    "generator",
+    "hazard_pointer",
+    "initializer_list",
+    "iomanip",
+    "ios",
+    "iosfwd",
+    "iostream",
+    "istream",
+    "iterator",
+    "latch",
+    "limits",
+    "list",
+    "locale",
+    "map",
+    "mdspan",
+    "memory",
+    "memory_resource",
+    "mutex",
+    "new",
+    "numbers",
+    "numeric",
+    "optional",
+    "ostream",
+    "print",
+    "queue",
+    "random",
+    "ranges",
+    "ratio",
+    "rcu",
+    "regex",
+    "scoped_allocator",
+    "semaphore",
+    "set",
+    "shared_mutex",
+    "source_location",
+    "span",
+    "spanstream",
+    "sstream",
+    "stack",
+    "stacktrace",
+    "stdexcept",
+    "stdfloat",
+    "stop_token",
+    "streambuf",
+    "string",
+    "string_view",
+    "strstream",
+    "syncstream",
+    "system_error",
+    "text_encoding",
+    "thread",
+    "tuple",
+    "typeindex",
+    "typeinfo",
+    "type_traits",
+    "unordered_map",
+    "unordered_set",
+    "utility",
+    "valarray",
+    "variant",
+    "vector",
+    "version",
+]
+
+# Added to the list of private headers during libcxx compilation.
+LIBCXX_MODULE_STD_INCLUDE_SOURCES_FILES = [
+    "modules/std/{}.inc".format(name)
+    for name in STD_PARTITIONS
+]
+
+# Substituted in std.cppm.in to generate std.cppm.
+LIBCXX_MODULE_STD_INCLUDE_SOURCES = "\n".join([
+    '#include "{}"'.format(file)
+    for file in LIBCXX_MODULE_STD_INCLUDE_SOURCES_FILES
+])
+
+copy_file(
+    name = "__assertion_handler_gen",
+    src = "vendor/llvm/default_assertion_handler.in",
+    out = "include/__assertion_handler",
+)
+
+expand_template(
+    name = "std.cppm",
+    out = "modules/std.cppm",
+    substitutions = {
+        "@LIBCXX_MODULE_STD_INCLUDE_SOURCES@": LIBCXX_MODULE_STD_INCLUDE_SOURCES,
+    },
+    template = "modules/std.cppm.in",
+)
+
+NO = "/* Undefined by Bazel. */"
+
+expand_template(
+    name = "__config_site_gen",
+    out = "include/__config_site",
+    substitutions = {
+        "#cmakedefine01 {}".format(name): "#define {} {}".format(name, value)
+        for name, value in {
+            "_LIBCPP_ABI_FORCE_ITANIUM": "0",
+            "_LIBCPP_ABI_FORCE_MICROSOFT": "0",
+            "_LIBCPP_HAS_THREADS": "1",
+            "_LIBCPP_HAS_MONOTONIC_CLOCK": "1",
+            "_LIBCPP_HAS_TERMINAL": "1",
+            "_LIBCPP_HAS_MUSL_LIBC": "0",
+            "_LIBCPP_HAS_THREAD_API_PTHREAD": "1",
+            "_LIBCPP_HAS_THREAD_API_EXTERNAL": "0",
+            "_LIBCPP_HAS_THREAD_API_WIN32": "0",
+            "_LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS": "0",
+            "_LIBCPP_HAS_FILESYSTEM": "1",
+            "_LIBCPP_HAS_RANDOM_DEVICE": "1",
+            "_LIBCPP_HAS_LOCALIZATION": "1",
+            "_LIBCPP_HAS_UNICODE": "1",
+            "_LIBCPP_HAS_WIDE_CHARACTERS": "1",
+            "_LIBCPP_HAS_TIME_ZONE_DATABASE": "1",
+            "_LIBCPP_INSTRUMENTED_WITH_ASAN": "0",
+        }.items()
+    } | {
+        "#cmakedefine _LIBCPP_ABI_VERSION @_LIBCPP_ABI_VERSION@": "#define _LIBCPP_ABI_VERSION 1",
+        "#cmakedefine _LIBCPP_ABI_NAMESPACE @_LIBCPP_ABI_NAMESPACE@": "#define _LIBCPP_ABI_NAMESPACE __1",
+        "#cmakedefine _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS": NO,
+        "#cmakedefine _LIBCPP_NO_VCRUNTIME": NO,
+        "#cmakedefine _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION @_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION@": NO,
+        "#cmakedefine _LIBCPP_HAS_NO_STD_MODULES": NO,
+        # PSTL backends.
+        "#cmakedefine _LIBCPP_PSTL_BACKEND_SERIAL": "#define _LIBCPP_PSTL_BACKEND_SERIAL",
+        "#cmakedefine _LIBCPP_PSTL_BACKEND_STD_THREAD": NO,
+        "#cmakedefine _LIBCPP_PSTL_BACKEND_LIBDISPATCH": NO,
+        # Hardening.
+        # TODO: Evaluate performance impact of this. If it isn't noticeable for
+        #       most use-cases, enable it.
+        "#cmakedefine _LIBCPP_HARDENING_MODE_DEFAULT @_LIBCPP_HARDENING_MODE_DEFAULT@": "#define _LIBCPP_HARDENING_MODE_DEFAULT _LIBCPP_HARDENING_MODE_NONE",
+        "@_LIBCPP_ABI_DEFINES@": NO,
+        "@_LIBCPP_EXTRA_SITE_DEFINES@": NO,
+    },
+    template = "include/__config_site.in",
+)
+
+[
+    filegroup(
+        name = "{}_headers".format(d.replace("/", "_")),
+        srcs = glob(["include/{}/*".format(d)]),
+        visibility = ["//visibility:public"],
+    )
+    for d in [
+        "__algorithm",
+        "__atomic",
+        "__bit",
+        "__charconv",
+        "__chrono",
+        "__compare",
+        "__concepts",
+        "__condition_variable",
+        "__configuration",
+        "__coroutine",
+        "__cstddef",
+        "__debug_utils",
+        "__exception",
+        "__expected",
+        "__filesystem",
+        "__flat_map",
+        "__format",
+        "__functional",
+        "__fwd",
+        "__ios",
+        "__iterator",
+        "__locale_dir",
+        "__math",
+        "__mdspan",
+        "__memory",
+        "__memory_resource",
+        "__mutex",
+        "__numeric",
+        "__ostream",
+        "__pstl",
+        "__random",
+        "__ranges",
+        "__stop_token",
+        "__string",
+        "__support",
+        "__system_error",
+        "__thread",
+        "__tuple",
+        "__type_traits",
+        "__utility",
+        "__variant",
+        "__vector",
+        "experimental",
+        "experimental/simd",
+        "ext",
+    ]
+]
+
+filegroup(
+    name = "top_level_headers",
+    srcs = glob(["include/*"], exclude=["include/CMakeLists.txt"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = glob(
+        [
+            "include/**/*",
+            "src/include/**/*",
+        ],
+        exclude = [
+            "include/**/CMakeLists.txt",
+            "include/__config_site.in",
+        ],
+    ) + [
+        ":__assertion_handler_gen",
+        ":__config_site_gen",
+    ],
+    includes = [
+        "include",
+        "src",
+        "src/include",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "sources",
+    srcs = glob(["src/**/*"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "c++",
+    srcs = [
+        "src/algorithm.cpp",
+        "src/any.cpp",
+        "src/bind.cpp",
+        "src/call_once.cpp",
+        "src/charconv.cpp",
+        "src/chrono.cpp",
+        "src/error_category.cpp",
+        "src/exception.cpp",
+        "src/filesystem/filesystem_clock.cpp",
+        "src/filesystem/filesystem_error.cpp",
+        "src/filesystem/path.cpp",
+        "src/functional.cpp",
+        "src/hash.cpp",
+        "src/legacy_pointer_safety.cpp",
+        "src/memory.cpp",
+        "src/memory_resource.cpp",
+        "src/new_handler.cpp",
+        "src/new_helpers.cpp",
+        "src/optional.cpp",
+        "src/print.cpp",
+        "src/random_shuffle.cpp",
+        "src/ryu/d2fixed.cpp",
+        "src/ryu/d2s.cpp",
+        "src/ryu/f2s.cpp",
+        "src/stdexcept.cpp",
+        "src/string.cpp",
+        "src/system_error.cpp",
+        "src/typeinfo.cpp",
+        "src/valarray.cpp",
+        "src/variant.cpp",
+        "src/vector.cpp",
+        "src/verbose_abort.cpp",
+
+        # Threads support.
+        "src/atomic.cpp",
+        "src/barrier.cpp",
+        "src/condition_variable_destructor.cpp",
+        "src/condition_variable.cpp",
+        "src/future.cpp",
+        "src/mutex_destructor.cpp",
+        "src/mutex.cpp",
+        "src/shared_mutex.cpp",
+        "src/thread.cpp",
+
+        # Random device support.
+        "src/random.cpp",
+
+        # Localization support.
+        "src/ios.cpp",
+        "src/ios.instantiations.cpp",
+        "src/iostream.cpp",
+        "src/locale.cpp",
+        "src/regex.cpp",
+        "src/strstream.cpp",
+
+        # Filesystem support.
+        "src/filesystem/directory_entry.cpp",
+        "src/filesystem/directory_iterator.cpp",
+        "src/filesystem/operations.cpp",
+
+        # "src/new.cpp",  # We pull this from libcxxabi for now.
+    ],
+    hdrs = [
+        # Files in src/include.
+        "src/include/apple_availability.h",
+        "src/include/atomic_support.h",
+        "src/include/config_elast.h",
+        "src/include/refstring.h",
+        "src/include/ryu/common.h",
+        "src/include/ryu/d2fixed.h",
+        "src/include/ryu/d2fixed_full_table.h",
+        "src/include/ryu/d2s.h",
+        "src/include/ryu/d2s_full_table.h",
+        "src/include/ryu/d2s_intrinsics.h",
+        "src/include/ryu/digit_table.h",
+        "src/include/ryu/f2s.h",
+        "src/include/ryu/ryu.h",
+        "src/include/to_chars_floating_point.h",
+
+        # Filesystem files.
+        "src/filesystem/error.h",  # Not in CMake.
+        "src/filesystem/file_descriptor.h",
+        "src/filesystem/format_string.h",  # Not in CMake.
+        "src/filesystem/path_parser.h",
+        "src/filesystem/posix_compat.h",
+        "src/filesystem/time_utils.h",
+
+        # Support ipp files.
+        "src/support/runtime/exception_fallback.ipp",
+        "src/support/runtime/exception_glibcxx.ipp",
+        "src/support/runtime/exception_libcxxabi.ipp",
+        "src/support/runtime/exception_libcxxrt.ipp",
+        "src/support/runtime/exception_msvc.ipp",
+        "src/support/runtime/exception_pointer_cxxabi.ipp",
+        "src/support/runtime/exception_pointer_glibcxx.ipp",
+        "src/support/runtime/exception_pointer_msvc.ipp",
+        "src/support/runtime/exception_pointer_unimplemented.ipp",
+        "src/support/runtime/stdexcept_default.ipp",
+        "src/support/runtime/stdexcept_vcruntime.ipp",
+
+        # Headers for building iostream.
+        "src/include/sso_allocator.h",
+        "src/iostream_init.h",
+        "src/std_stream.h",
+
+        # This seems to be forgotten in CMake.
+        "src/memory_resource_init_helper.h",
+    ] + LIBCXX_MODULE_STD_INCLUDE_SOURCES_FILES,
+    copts = [
+        "-std=c++2b",
+        "-faligned-allocation",
+        "-fno-omit-frame-pointer",
+        "-funwind-tables",
+        "-fstrict-aliasing",
+        "-fvisibility-inlines-hidden",
+        "-Wno-user-defined-literals",
+        "-Wno-reserved-module-identifier",
+
+        # TODO: Remove this after resolve of
+        # https://github.com/llvm/llvm-project/issues/62844
+        "-Wno-deprecated-declarations",
+        "-nostdinc++",
+    ],
+    defines = [
+        "_LIBCPP_BUILDING_LIBRARY",
+        "_LIBCPP_ENABLE_EXPERIMENTAL",
+        "_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER",
+        "_LIBCPP_LINK_PTHREAD_LIB",
+        "_LIBCPP_LINK_RT_LIB",
+        "_LIBCPP_REMOVE_TRANSITIVE_INCLUDES",
+        "_LIBCXXABI_BUILDING_LIBRARY",
+        "LIBCXX_BUILDING_LIBCXXABI",
+    ],
+    includes = [
+        "include",  # Used for modules which are included as `modules/std/...`.
+        "src",
+        "src/include",
+    ],
+    features = ["-libc++", "-libstdc++"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@llvm-project//libc:libc_external_common",
+        "@llvm-project//libcxxabi:c++abi",
+    ],
+)

--- a/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
@@ -1,0 +1,89 @@
+filegroup(
+    name = "headers",
+    srcs = [
+        "include/__cxxabi_config.h",
+        "include/cxxabi.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "c++abi",
+    srcs = [
+        # C++ABI files
+        "src/cxa_aux_runtime.cpp",
+        "src/cxa_default_handlers.cpp",
+        "src/cxa_demangle.cpp",
+        "src/cxa_exception_storage.cpp",
+        "src/cxa_guard.cpp",
+        "src/cxa_handlers.cpp",
+        "src/cxa_thread_atexit.cpp",
+        "src/cxa_vector.cpp",
+        "src/cxa_virtual.cpp",
+
+        # C++ STL files
+        "src/stdlib_exception.cpp",
+        "src/stdlib_stdexcept.cpp",
+        "src/stdlib_typeinfo.cpp",
+
+        # Internal files
+        "src/abort_message.cpp",
+        "src/fallback_malloc.cpp",
+        "src/private_typeinfo.cpp",
+
+        # New/Delete
+        "src/stdlib_new_delete.cpp",
+
+        # Exceptions
+        "src/cxa_exception.cpp",
+        "src/cxa_personality.cpp",
+    ],
+    hdrs = glob(["include/**"]) + [
+        # C++ABI files.
+        "src/cxa_handlers.h",
+        "src/cxa_guard_impl.h",
+
+        # C++ STL files.
+        "src/abort_message.h",
+        "src/fallback_malloc.h",
+        "src/private_typeinfo.h",
+
+        # Exceptions.
+        "src/cxa_exception.h",
+
+        # Demangle
+        "src/demangle/DemangleConfig.h",
+        "src/demangle/ItaniumDemangle.h",
+        "src/demangle/ItaniumNodes.def",
+        "src/demangle/StringViewExtras.h",
+        "src/demangle/Utility.h",
+    ],
+    copts = [
+        "-std=c++2b",
+        "-faligned-allocation",
+        "-funwind-tables",
+        "-fstrict-aliasing",
+        "-fvisibility-inlines-hidden",
+        "-nostdinc++",
+    ],
+    data = [
+        "@llvm-project//libcxx:sources",
+    ],
+    defines = [
+        "LIBCXX_BUILDING_LIBCXXABI",
+        "HAVE___CXA_THREAD_ATEXIT_IMPL",  # 3 underscores.
+        "LIBCXXABI_USE_LLVM_UNWINDER",
+        "_LIBCPP_BUILDING_LIBRARY",
+        "_LIBCXXABI_BUILDING_LIBRARY",
+        "_LIBCXXABI_LINK_PTHREAD_LIB",
+    ],
+    deps = [
+        "@llvm-project//libcxx:headers",
+    ],
+    includes = [
+        "src",
+        "include",
+    ],
+    features = ["-libc++", "-libstdc++"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add bazel overlays for compiler-rt, libcxx, and libcxxabi. This allows building most of the clang components we need using bazel.
