### PR TITLE
[mlir] Allow forcing op printing to assume the op is at the top level

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1179,6 +1179,9 @@ public:
   /// the full module.
   OpPrintingFlags &useLocalScope();
 
+  /// Force printing as if this op were at the top level.
+  OpPrintingFlags &forceTopLevel();
+
   /// Print users of values as comments.
   OpPrintingFlags &printValueUsers();
 
@@ -1221,6 +1224,9 @@ public:
   /// Return if printer should use unique SSA IDs.
   bool shouldPrintUniqueSSAIDs() const;
 
+  /// Return if the printer should force top level printing.
+  bool shouldForceTopLevel() const;
+
 private:
   /// Elide large elements attributes if the number of elements is larger than
   /// the upper limit.
@@ -1254,6 +1260,8 @@ private:
 
   /// Print unique SSA IDs for values, block arguments and naming conflicts
   bool printUniqueSSAIDsFlag : 1;
+
+  bool printForceTopLevel : 1;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -296,6 +296,11 @@ OpPrintingFlags &OpPrintingFlags::printValueUsers() {
   return *this;
 }
 
+OpPrintingFlags &OpPrintingFlags::forceTopLevel() {
+  printForceTopLevel = true;
+  return *this;
+}
+
 /// Return if the given ElementsAttr should be elided.
 bool OpPrintingFlags::shouldElideElementsAttr(ElementsAttr attr) const {
   return elementsAttrElementLimit &&
@@ -361,6 +366,8 @@ bool OpPrintingFlags::shouldPrintValueUsers() const {
 bool OpPrintingFlags::shouldPrintUniqueSSAIDs() const {
   return printUniqueSSAIDsFlag || shouldPrintGenericOpForm();
 }
+
+bool OpPrintingFlags::shouldForceTopLevel() const { return printForceTopLevel; }
 
 //===----------------------------------------------------------------------===//
 // NewLineCounter
@@ -3961,7 +3968,7 @@ void Operation::print(raw_ostream &os, const OpPrintingFlags &printerFlags) {
 }
 void Operation::print(raw_ostream &os, AsmState &state) {
   OperationPrinter printer(os, state.getImpl());
-  if (!getParent() && !state.getPrinterFlags().shouldUseLocalScope()) {
+  if (state.getPrinterFlags().shouldForceTopLevel() || (!getParent() && !state.getPrinterFlags().shouldUseLocalScope())) {
     state.getImpl().initializeAliases(this);
     printer.printTopLevelOperation(this);
   } else {


### PR DESCRIPTION
This will allow printing dialect resources for ops that are not at the top level.
