### PR TITLE
Allow suppressing static_var_with_dynamic_init

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1431,6 +1431,9 @@ def CudaCompat : DiagGroup<"cuda-compat">;
 // Warning about unknown CUDA SDK version.
 def CudaUnknownVersion: DiagGroup<"unknown-cuda-version">;
 
+// A warning group equivalent to nvcc's static_var_with_dynamic_init diag.
+def CudaStaticVarWithDynamicInit : DiagGroup<"cuda-static-var-with-dynamic-init">;
+
 // A warning group for warnings about features supported by HIP but
 // ignored by CUDA.
 def HIPOnly : DiagGroup<"hip-only">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9113,11 +9113,11 @@ def note_cuda_conflicting_device_function_declared_here : Note<
 def err_cuda_device_exceptions : Error<
   "cannot use '%0' in "
   "%select{__device__|__global__|__host__|__host__ __device__}1 function">;
-def err_dynamic_var_init : Error<
+def warn_dynamic_var_init : Warning<
     "dynamic initialization is not supported for "
-    "__device__, __constant__, __shared__, and __managed__ variables">;
-def err_shared_var_init : Error<
-    "initialization is not supported for __shared__ variables">;
+    "__device__, __constant__, __shared__, and __managed__ variables">, InGroup<CudaStaticVarWithDynamicInit>, DefaultError;
+def warn_shared_var_init : Warning<
+    "initialization is not supported for __shared__ variables">, InGroup<CudaStaticVarWithDynamicInit>, DefaultError;
 def err_cuda_vla : Error<
     "cannot use variable-length arrays in "
     "%select{__device__|__global__|__host__|__host__ __device__}0 functions">;

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -676,9 +676,8 @@ void SemaCUDA::checkAllowedInitializer(VarDecl *VD) {
             *this, VD, IsSharedVar ? CICK_Shared : CICK_DeviceOrConstant))
       return;
     Diag(VD->getLocation(),
-         IsSharedVar ? diag::err_shared_var_init : diag::err_dynamic_var_init)
+         IsSharedVar ? diag::warn_shared_var_init : diag::warn_dynamic_var_init)
         << Init->getSourceRange();
-    VD->setInvalidDecl();
   } else {
     // This is a host-side global variable.  Check that the initializer is
     // callable from the host side.

--- a/clang/test/SemaCUDA/device-var-init.cu
+++ b/clang/test/SemaCUDA/device-var-init.cu
@@ -429,6 +429,13 @@ __device__ void df_sema() {
   // expected-error@-1 {{initialization is not supported for __shared__ variables}}
   static __constant__ T_FA_NED c_t_fa_ned;
   // expected-error@-1 {{dynamic initialization is not supported for __device__, __constant__, __shared__, and __managed__ variables}}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcuda-static-var-with-dynamic-init"
+  static __device__ T_FA_NED d_t_fa_ned_ignored;
+  static __shared__ T_FA_NED s_t_fa_ned_ignored;
+  static __constant__ T_FA_NED c_t_fa_ned_ignored;
+#pragma clang diagnostic pop
 }
 
 __host__ __device__ void hd_sema() {


### PR DESCRIPTION
CUDA disallows initialization of shared variables with non-default constructors. However, CUDA has a `pipeline_shared_state` object that has a non-default constructor, and it seems to be a common CUDA pattern to do:
```
#pragma nv_diag_suppress static_var_with_dynamic_init
...
__shared__ cuda::pipeline_shared_state<cuda::thread_scope::thread_scope_block, STAGES / SEQ_UNROLL> pipeline_state;
```

However, clang always errors on this code and does not support disabling the error. This PR switches the error to a warning that is default to an error, this allows using `clang diagnostic push/pop` to disable the warning for parts of the code.
