### PR TITLE
Fix bug in LivenessAnalysis

### DIFF
--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -51,7 +51,8 @@ ChangeResult Liveness::meet(const AbstractSparseLattice &other) {
 /// A value is considered "live" iff it:
 ///   (1) has memory effects OR
 ///   (2) is returned by a public function OR
-///   (3) is used to compute a value of type (1) or (2).
+///   (2.b) is a block argument of a public function OR
+///   (3) is used to compute a value of type (1), (2) or (2.b)
 /// It is also to be noted that a value could be of multiple types (1/2/3) at
 /// the same time.
 ///
@@ -89,6 +90,20 @@ LivenessAnalysis::visitOperation(Operation *op, ArrayRef<Liveness *> operands,
     }
     addDependency(const_cast<Liveness *>(r), getProgramPointAfter(op));
   }
+
+  // This marks values of type (2.b) liveness as "live".
+  if (auto callable = dyn_cast<CallableOpInterface>(op)) {
+    auto symbol = dyn_cast<SymbolOpInterface>(op);
+    if (symbol && symbol.isPublic()) {
+      auto *region = callable.getCallableRegion();
+      if (region && !region->empty())
+        for (auto arg : region->front().getArguments()) {
+          auto latticeElement = getLatticeElement(arg);
+          propagateIfChanged(latticeElement, latticeElement->markLive());
+        }
+    }
+  }
+
   return success();
 }
 


### PR DESCRIPTION
This fixes a bug in the LivenessAnalysis.

Without this patch the LivenessAnalysis would not consider block arguments of public functions to be "live".
This had downstream consequences one the RemoveDeadValues pass.
The RemoveDeadValues pass assumes that public functions don't need to be modified, but this leads to null operands in the IR when providers for arguments are removed from any callsites but the call op is not updated to remove those arguments.

I will try to upstream this patch, as I think its a legitmate bug.
