### PR TITLE
[GML] Avoid calling isMemoryEffectFree on ops that have deleted operands

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -175,7 +175,7 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 /// symbol op, a symbol-user op, a region branch op, a branch op, a region
 /// branch terminator op, or return-like.
 static void cleanSimpleOp(Operation *op, RunLivenessAnalysis &la) {
-  if (!isMemoryEffectFree(op) || hasLive(op->getResults(), la))
+  if (hasLive(op->getResults(), la))
     return;
 
   op->dropAllUses();


### PR DESCRIPTION
This bug is fixed in newer LLVM.
