### PR TITLE
Replace inserter() with inserts to work-around C++20 strict requirement/bug in libstdc++10

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -327,8 +327,12 @@ static void createNewAliasScopesFromNoAliasParameter(
             getUnderlyingObjectSet(pointer);
         if (failed(underlyingObjectSet))
           return;
-        llvm::copy(*underlyingObjectSet,
-                   std::inserter(basedOnPointers, basedOnPointers.begin()));
+        // Switched from llvm::copy(*underlyingObjectSet,
+        // std::inserter(basedonPointers, ...)) to support libstdc++10 and
+        // C++20. We need to support this so that python bindings can be built
+        // with widely compatible versions of glibc.
+        for (Value v : *underlyingObjectSet)
+          basedOnPointers.insert(v);
       }
 
       bool aliasesOtherKnownObject = false;


### PR DESCRIPTION
We pull in the mlir package for the gimlet-api python package. We compile this with manylinux 2.31 to be compatible with more environments. However we also compile with C++20 because we need to support new language features.

manylinux uses libstdc++10 which has early, but buggy/restrictive support for C++20, especially around iterator concepts like std::inserter. Namely the std::inserter expects that iterators are default constructible, which is not the case for SmallPtrSetIterator. Explored trying to work-around this, but template substitution was an impassible barrier for this problem.

So to get around this, we're fixing the one usage that caused problems by switching away from an iterator implementation.


Signed-off-by: Phillip Kuznetsov <philkuz@gimletlabs.ai>
