### PR TITLE
Fix issues with c++23.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -515,6 +515,13 @@ private:
   struct BlockInfo {
     std::unique_ptr<WaitcntBrackets> Incoming;
     bool Dirty = true;
+
+    BlockInfo();
+    ~BlockInfo();
+    BlockInfo(BlockInfo &&) noexcept;
+    BlockInfo &operator=(BlockInfo &&) noexcept;
+    BlockInfo(const BlockInfo &) = delete;
+    BlockInfo &operator=(const BlockInfo &) = delete;
   };
 
   MapVector<MachineBasicBlock *, BlockInfo> BlockInfos;
@@ -1005,6 +1012,12 @@ private:
   // mark yet. Initialized to all zeros.
   CounterValueArray AsyncScore{};
 };
+
+SIInsertWaitcnts::BlockInfo::BlockInfo() = default;
+SIInsertWaitcnts::BlockInfo::~BlockInfo() = default;
+SIInsertWaitcnts::BlockInfo::BlockInfo(BlockInfo &&) noexcept = default;
+SIInsertWaitcnts::BlockInfo &
+SIInsertWaitcnts::BlockInfo::operator=(BlockInfo &&) noexcept = default;
 
 class SIInsertWaitcntsLegacy : public MachineFunctionPass {
 public:

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -1097,6 +1097,7 @@ cc_library(
 PYBIND11_COPTS = [
     "-fexceptions",
     "-frtti",
+    "-std=c++20",
 ]
 
 PYBIND11_FEATURES = [


### PR DESCRIPTION
Fixes an issue in AMDGPU target with c++23.
Forces C++20, for the mlir python bindings, since there seems to be a number of problems there with c++23.
