### PR TITLE
[Inliner] Scope MLIR inliner symbol-ref caching per operation

### DIFF
--- a/mlir/lib/Transforms/Utils/Inliner.cpp
+++ b/mlir/lib/Transforms/Utils/Inliner.cpp
@@ -127,7 +127,7 @@ CGUseList::CGUseList(Operation *op, CallGraph &cg,
                      SymbolTableCollection &symbolTable)
     : symbolTable(symbolTable) {
   /// A set of callgraph nodes that are always known to be live during inlining.
-  DenseMap<Attribute, CallGraphNode *> alwaysLiveNodes;
+  DenseSet<CallGraphNode *> alwaysLiveNodes;
 
   // Walk each of the symbol tables looking for discardable callgraph nodes.
   auto walkFn = [&](Operation *symbolTableOp, bool allUsesVisible) {
@@ -144,16 +144,21 @@ CGUseList::CGUseList(Operation *op, CallGraph &cg,
         }
       }
       // Otherwise, check for any referenced nodes. These will be always-live.
-      walkReferencedSymbolNodes(&op, cg, symbolTable, alwaysLiveNodes,
-                                [](CallGraphNode *, Operation *) {});
+      // Keep symbol resolution scoped to this operation. The same flat symbol
+      // ref can refer to different callgraph nodes in sibling symbol tables.
+      DenseMap<Attribute, CallGraphNode *> resolvedRefs;
+      walkReferencedSymbolNodes(&op, cg, symbolTable, resolvedRefs,
+                                [&](CallGraphNode *node, Operation *) {
+                                  alwaysLiveNodes.insert(node);
+                                });
     }
   };
   SymbolTable::walkSymbolTables(op, /*allSymUsesVisible=*/!op->getBlock(),
                                 walkFn);
 
   // Drop the use information for any discardable nodes that are always live.
-  for (auto &it : alwaysLiveNodes)
-    discardableSymNodeUses.erase(it.second);
+  for (CallGraphNode *node : alwaysLiveNodes)
+    discardableSymNodeUses.erase(node);
 
   // Compute the uses for each of the callable nodes in the graph.
   for (CallGraphNode *node : cg)

--- a/mlir/test/Transforms/inlining-symbol-ref-cache.mlir
+++ b/mlir/test/Transforms/inlining-symbol-ref-cache.mlir
@@ -1,0 +1,29 @@
+// RUN: mlir-opt %s -allow-unregistered-dialect -inline='default-pipeline=''' | FileCheck %s
+
+// The same flat symbol ref can refer to different symbols in different sibling
+// symbol tables. Inliner liveness must resolve symbol refs in their local scope
+// instead of reusing a previous resolution from another symbol table.
+
+module {
+  // CHECK-LABEL: module @prefill
+  module @prefill {
+    // CHECK: "test.symbol_ref_attr"() {symbol = @shared}
+    "test.symbol_ref_attr"() {symbol = @shared} : () -> ()
+
+    // CHECK: func.func private @shared()
+    func.func private @shared() {
+      return
+    }
+  }
+
+  // CHECK-LABEL: module @decode
+  module @decode {
+    // CHECK: "test.symbol_ref_attr"() {symbol = @shared}
+    "test.symbol_ref_attr"() {symbol = @shared} : () -> ()
+
+    // CHECK: func.func private @shared()
+    func.func private @shared() {
+      return
+    }
+  }
+}


### PR DESCRIPTION
Summary: Fixes incorrect inliner liveness for duplicate private symbols in sibling symbol tables. The inliner now resolves non-call symbol refs in their local scope and records actual live callgraph nodes, preventing one module’s export from incorrectly keeping another module’s same-named function alive while DCE removes the local one.