### PR TITLE
Fix GCC 10 compatibility in SampleProf

### DIFF
--- a/llvm/lib/ProfileData/SampleProf.cpp
+++ b/llvm/lib/ProfileData/SampleProf.cpp
@@ -337,8 +337,10 @@ const FunctionSamples *FunctionSamples::findFunctionSamples(
 
 void FunctionSamples::findAllNames(DenseSet<FunctionId> &NameSet) const {
   NameSet.insert(getFunction());
-  for (const auto &BS : BodySamples)
-    NameSet.insert_range(llvm::make_first_range(BS.second.getCallTargets()));
+  for (const auto &BS : BodySamples) {
+    auto CallTargets = llvm::make_first_range(BS.second.getCallTargets());
+    NameSet.insert(CallTargets.begin(), CallTargets.end());
+  }
 
   for (const auto &CS : CallsiteSamples) {
     for (const auto &NameFS : CS.second) {


### PR DESCRIPTION
## Summary
- replace the C++23-style `DenseSet::insert_range` call with iterator-based insertion
- preserve the existing call-target name collection behavior while supporting GCC 10

## Test plan
- [ ] Build LLVM's ProfileData library with GCC 10


Made with [Cursor](https://cursor.com)